### PR TITLE
Make comma-separated selectors work

### DIFF
--- a/index.js
+++ b/index.js
@@ -192,26 +192,32 @@ function HTMLElement(tag) {
 var elRe = /([.#:[])([-\w]+)(?:=([-\w]+)])?]?/g
 
 function findEl(node, sel, first) {
-	var el
-	, i = 0
-	, out = []
-	, rules = ["_"]
-	, tag = sel.replace(elRe, function(_, o, s, v) {
-		rules.push(
-			o == "." ? "(' '+_.className+' ').indexOf(' "+s+" ')>-1" :
-			o == "#" ? "_.id=='"+s+"'" :
-			"_.getAttribute('"+s+"')"+(v?"=='"+v+"'":"")
-		)
-		return ""
-	}) || "*"
-	, els = node.getElementsByTagName(tag)
-	, fn = Function("_", "return " + rules.join("&&")) // jshint evil:true
+	var sels = sel.split(/\s*,\s*/)
+	, j = 0
+	, out = [];
 
-	// jshint -W084
-	for (; el = els[i++]; ) if (fn(el)) {
-		if (first) return el
-		out.push(el)
+	for (; sel = sels[j++]; ) {
+		var el
+		, i = 0
+		, rules = ["_"]
+		, tag = sel.replace(elRe, function(_, o, s, v) {
+			rules.push(
+				o == "." ? "(' '+_.className+' ').indexOf(' "+s+" ')>-1" :
+				o == "#" ? "_.id=='"+s+"'" :
+				"_.getAttribute('"+s+"')"+(v?"=='"+v+"'":"")
+			)
+			return ""
+		}) || "*"
+		, els = node.getElementsByTagName(tag)
+		, fn = Function("_", "return " + rules.join("&&")) // jshint evil:true
+
+		// jshint -W084
+		for (; el = els[i++]; ) if (fn(el)) {
+			if (first) return el
+			out.push(el)
+		}
 	}
+
 	return first ? null : out
 }
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -331,6 +331,8 @@ test("getElementById, getElementsByTagName, querySelector", function (assert) {
     assert.equal(document.querySelectorAll("div").length,         8)
     assert.equal(document.querySelectorAll(".findme").length,     2)
     assert.equal(document.querySelectorAll("span.findme").length, 1)
+    assert.equal(document.querySelectorAll("span.findme, div.findme").length, 2)
+
     assert.end()
 })
 


### PR DESCRIPTION
Just wrapped querySelector so to split selector by commas.

That’s for #16.

@lauriro @hayes 