### PR TITLE
Update dev dependencies so that 'npm test' works on clean environments.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build": "node node_modules/buildman/index.js --all",
     "travis-test": "istanbul cover ./tests/index.js && (coveralls < coverage/lcov.info || exit 0)",
     "cover-climate": "istanbul cover ./tests/index.js && (codeclimate < coverage/lcov.info || exit 0)",
-    "test": "faucet; jshint --verbose index.js"
+    "test": "node_modules/.bin/faucet; node_modules/.bin/jshint --verbose index.js"
   },
   "repository": "git://github.com/litejs/dom-lite.git",
   "bugs": {
@@ -28,7 +28,9 @@
   },
   "devDependencies": {
     "buildman": "*",
-    "tape": "2.12.x"
+    "tape": "2.12.x",
+    "faucet": "*",
+    "jshint": "*"
   },
   "jshintConfig": {
     "asi": true,


### PR DESCRIPTION
The previous version of the npm test script assumed that jshint and faucet are available in the path.
This change includes them as devDependencies, simplifying the process for running tests when checked out into a clean environment.